### PR TITLE
[WIP] Support for Microsoft Crypto Extensions

### DIFF
--- a/src/viewer/index.handlebars
+++ b/src/viewer/index.handlebars
@@ -371,6 +371,89 @@
             {{/each}}
           {{/if}}
 
+          {{! Microsoft Crypto Extensions}}
+          {{#if this.ext.msCryptoExt.required}}
+          <div class="panel-section-subsection">Microsoft Cryptography Extensions</div>
+          {{/if}}
+          
+          {{! MS Enrollment certificate types }}
+          {{#if this.ext.msCryptoExt.enrollmentType}}
+            <div class="panel-section-subheader">
+              <span>
+                {{#if this.ext.msCryptoExt.enrollmentType.critical}}<img class="critical" alt="critical extension" title="This extension has been marked as critical, meaning that clients must reject the certificate if they don't understand it." src="../icons/critical.svg">{{/if~}}
+                Enrollment Type
+              </span>
+            </div>
+            <div class="panel-list-item">
+              <div class="text">OID</div>   {{! 'Name' will come here }}
+              <div class="text long-hex long-hex-box">{{ this.ext.msCryptoExt.enrollmentType.oid }}</div>
+            </div>
+          {{/if}}
+
+          {{! MS Certificate services ca version }}
+          {{#if this.ext.msCryptoExt.certservCA}}
+            <div class="panel-section-subheader">
+              <span>
+                {{#if this.ext.msCryptoExt.certservCA.critical}}<img class="critical" alt="critical extension" title="This extension has been marked as critical, meaning that clients must reject the certificate if they don't understand it." src="../icons/critical.svg">{{/if~}}
+                CA Version
+              </span>
+            </div>
+            <div class="panel-list-item">
+              <div class="text">OID</div>   {{! 'CA Version ID' will come here }}
+              <div class="text long-hex long-hex-box">{{ this.ext.msCryptoExt.certservCA.oid }}</div>
+            </div>
+          {{/if}}
+
+          {{! MS Certificate servives previous certificate hash }}
+          {{#if this.ext.msCryptoExt.certservHash}}
+              <div class="panel-section-subheader">
+                <span>
+                {{#if this.ext.msCryptoExt.certservHash.critical}}<img class="critical" alt="critical extension" title="This extension has been marked as critical, meaning that clients must reject the certificate if they don't understand it." src="../icons/critical.svg">{{/if}}
+                Certificate Hash
+                </span>
+              </div>
+              <div class="panel-list-item">
+                <div class="text">OID</div>
+                <div class="text breakable">{{ this.ext.msCryptoExt.certservHash.oid }}</div>
+              </div>
+          {{/if}}
+
+          {{! MS Certificate template }}
+          {{#if this.ext.msCryptoExt.certTemplate}}
+            <div class="panel-section-subheader">
+              <span>
+                {{#if this.ext.msCryptoExt.certTemplate.critical}}<img class="critical" alt="critical extension" title="This extension has been marked as critical, meaning that clients must reject the certificate if they don't understand it." src="../icons/critical.svg">{{/if~}}
+                Certificate Template
+              </span>
+            </div>
+            <div class="panel-list-item">
+              <div class="text">Template ID</div>
+              <div class="text long-hex long-hex-box">{{ this.ext.msCryptoExt.certTemplate.templateID }}</div>
+            </div>
+            {{!-- <div class="panel-list-item">
+              <div class="text">Major Version</div>
+              <div class="text long-hex long-hex-box">{{ this.ext.msCryptoExt.certTemplate.templateMajorVersion }}</div>
+            </div>
+            <div class="panel-list-item">
+              <div class="text">Minor Version</div>
+              <div class="text long-hex long-hex-box">{{ this.ext.msCryptoExt.certTemplate.templateMinorVersion }}</div>
+            </div> --}}
+          {{/if}}
+
+          {{! MS Application certificate policy }}
+          {{#if this.ext.msCryptoExt.applicationPolicy}}
+            <div class="panel-section-subheader">
+              <span>
+                {{#if this.ext.msCryptoExt.applicationPolicy.critical}}<img class="critical" alt="critical extension" title="This extension has been marked as critical, meaning that clients must reject the certificate if they don't understand it." src="../icons/critical.svg">{{/if~}}
+                Application Policy
+              </span>
+            </div>
+            <div class="panel-list-item">
+              <div class="text">OID</div>
+              <div class="text breakable">{{ this.ext.msCryptoExt.applicationPolicy.oid }}</div>
+            </div>
+          {{/if}}
+
           {{! Unsupported extensions }}
           {{#if (truthy this.unsupportedExtensions)}}
             <div class="panel-section-subheader">

--- a/src/viewer/js/strings.js
+++ b/src/viewer/js/strings.js
@@ -50,6 +50,38 @@ export const strings = {
       }
     },
 
+    // Microsoft Cryptography Extensions
+    '1.3.6.1.4.1.311.20.2': {
+      name: {
+          short:'Enroll CertType',
+          long:'Microsoft Enrollment Certificate Type',
+      }
+    },
+    '1.3.6.1.4.1.311.21.1': {
+      name: {
+          short:'CertServ CA',
+          long:'Microsoft Certificate Services CA Version',
+      }
+    },
+    '1.3.6.1.4.1.311.21.2': {
+      name: {
+          short:'CertServ Hash',
+          long:'Microsoft Certificate Servives Previous Certificate Hash',
+      }
+    },
+    '1.3.6.1.4.1.311.21.7': {
+      name: {
+          short:'CertType Template',
+          long:'Microsoft Certificate Template',
+      }
+    },
+    '1.3.6.1.4.1.311.21.10': {
+      name: {
+          short:'AppCert Policy',
+          long:'Microsoft Application Certificate Policy',
+      }
+    },
+
     // X.500 attribute types
     '2.5.4.1': {
       short: undefined,

--- a/src/viewer/js/strings.js
+++ b/src/viewer/js/strings.js
@@ -53,31 +53,31 @@ export const strings = {
     // Microsoft Cryptography Extensions
     '1.3.6.1.4.1.311.20.2': {
       name: {
-          short:'Enroll CertType',
+          short:'Enrollment Type',
           long:'Microsoft Enrollment Certificate Type',
       }
     },
     '1.3.6.1.4.1.311.21.1': {
       name: {
-          short:'CertServ CA',
+          short:'CA Version',
           long:'Microsoft Certificate Services CA Version',
       }
     },
     '1.3.6.1.4.1.311.21.2': {
       name: {
-          short:'CertServ Hash',
+          short:'Certificate Hash',
           long:'Microsoft Certificate Servives Previous Certificate Hash',
       }
     },
     '1.3.6.1.4.1.311.21.7': {
       name: {
-          short:'CertType Template',
+          short:'Certificate Template',
           long:'Microsoft Certificate Template',
       }
     },
     '1.3.6.1.4.1.311.21.10': {
       name: {
-          short:'AppCert Policy',
+          short:'Application Policy',
           long:'Microsoft Application Certificate Policy',
       }
     },


### PR DESCRIPTION
The OID's are being displayed for all extensions currently. I could find the ans1 formats for enrollment type, CA version and certificate template. @april shall I work on implementing them?

Screenshots:

![Screenshot 1](https://user-images.githubusercontent.com/33131404/54650711-c7145a00-4ad5-11e9-9c0c-59f08fc29f0f.png)

![Screenshot 2](https://user-images.githubusercontent.com/33131404/54650714-c8de1d80-4ad5-11e9-89e6-7c7fc1639af2.png)

![Screenshot 3](https://user-images.githubusercontent.com/33131404/54650717-caa7e100-4ad5-11e9-8892-6bf256475a5d.png)

ANS1 Formats:
Enrollment Type: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/3aec3e50-511a-42f9-a5d5-240af503e470
Certificate Template: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/9da866e5-9ce9-4a83-9064-0d20af8b2ccf
